### PR TITLE
Fix "boolean" parameter not working with $column array in Builder.php

### DIFF
--- a/Query/Builder.php
+++ b/Query/Builder.php
@@ -572,12 +572,12 @@ class Builder
      */
     protected function addArrayOfWheres($column, $boolean, $method = 'where')
     {
-        return $this->whereNested(function ($query) use ($column, $method) {
+        return $this->whereNested(function ($query) use ($column, $method, $boolean) {
             foreach ($column as $key => $value) {
                 if (is_numeric($key) && is_array($value)) {
                     $query->{$method}(...array_values($value));
                 } else {
-                    $query->$method($key, '=', $value);
+                    $query->$method($key, '=', $value, $boolean);
                 }
             }
         }, $boolean);


### PR DESCRIPTION
Fixed: passing the "boolean" parameter to function "where" didn't work in case of $column being an array. 
This was due to the callback function was missing the $boolean parameter, thus the default value "and" always was used